### PR TITLE
Deploymentsを定期的に再起動させてイメージを最新に保つ

### DIFF
--- a/pod-restarter/clusterrole.yaml
+++ b/pod-restarter/clusterrole.yaml
@@ -1,0 +1,20 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-restarter
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - delete
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list

--- a/pod-restarter/clusterrolebinding.yaml
+++ b/pod-restarter/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-restarter
+subjects:
+  - kind: ServiceAccount
+    name: pod-restarter
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: pod-restarter
+  apiGroup: rbac.authorization.k8s.io

--- a/pod-restarter/cronjob.yaml
+++ b/pod-restarter/cronjob.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: pod-restarter
+spec:
+  schedule: "0 2 * * *"
+  concurrencyPolicy: Replace
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccount: pod-restarter
+          restartPolicy: Never
+          containers:
+            - name: pod-restarter
+              image: bitnami/kubectl:latest
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  kubectl get deployments -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | xargs -I "{}" kubectl rollout restart deployments {}

--- a/pod-restarter/job.yaml
+++ b/pod-restarter/job.yaml
@@ -1,0 +1,18 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pod-restarter
+  labels:
+    app: pod-restarter
+spec:
+  template:
+    spec:
+      serviceAccount: pod-restarter
+      restartPolicy: Never
+      containers:
+        - name: pod-restarter
+          image: bitnami/kubectl:latest
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              kubectl get deployments -o=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | xargs -I "{}" kubectl rollout restart deployments {}

--- a/pod-restarter/kustomization.yaml
+++ b/pod-restarter/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - cronjob.yaml
+  - serviceaccount.yaml
+  - clusterrole.yaml
+  - clusterrolebinding.yaml

--- a/pod-restarter/serviceaccount.yaml
+++ b/pod-restarter/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-restarter


### PR DESCRIPTION
## 概要

イメージのバージョン管理が面倒なので Deployments たちを定期的に再起動させてイメージを最新にします（良い子は真似しないでね）