### PR TITLE
ExternalSecretsのデプロイ先のNamespaceを変更する

### DIFF
--- a/argocd-application/external-secrets.application.yaml
+++ b/argocd-application/external-secrets.application.yaml
@@ -13,4 +13,9 @@ spec:
       releaseName: external-secrets
   destination:
     server: "https://kubernetes.default.svc"
-    namespace: kubeseal
+    namespace: external-secrets
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## 概要

- Namespace が SealedSecret のものになっていたので変更
- Namespace を自動で作成するように SyncOption を追加
  - [`CreateNamespace=true`](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/#create-namespace)
  - 